### PR TITLE
Resolves: Consolidate current pipelines into a single pipeline with additional features

### DIFF
--- a/.github/workflows/ci-cd-sharedkernel.yml
+++ b/.github/workflows/ci-cd-sharedkernel.yml
@@ -23,11 +23,26 @@ jobs:
           $defaultBranch = Invoke-RestMethod -Method GET -Uri https://api.github.com/repos/$repo | Select-Object -ExpandProperty default_branch
           Write-Output "::set-output name=default_branch::$(echo $defaultBranch)"
 
+      - name: Conditionals handler
+        id: conditionals_handler
+        shell: pwsh
+        run: |
+          $defaultBranch = "${{ steps.data_gatherer.outputs.default_branch }}"
+          $githubRef = "${{ github.ref }}"
+          $currentBranch = $githubRef -replace 'refs/heads/', ''
+          $isDefaultBranch = 'false'
+
+          if ( $currentBranch -eq $defaultBranch ) {
+            $isDefaultBranch = 'true'
+          }
+          
+          Write-Output "::set-output name=is_default_branch::$(echo $isDefaultBranch)"
+
       - name: Setup .NET Core
         id: setup_dotnet_core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.102
+          dotnet-version: 5.0.301
 
       - name: Checkout repository
         id: checkout_repo
@@ -35,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - if: steps.data_gatherer.outputs.default_branch == 'true'
+      - if: steps.conditionals_handler.outputs.is_default_branch == 'true'
         name: Bump GH tag
         id: tag_generator
         uses: mathieudutour/github-tag-action@v5.4
@@ -102,10 +117,12 @@ jobs:
 
       - name: Create and publish release
         id: create_release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: PluralsightDdd.SharedKernel ${{ needs.ci.outputs.latest_version }}
-          tag_name: v${{ needs.ci.outputs.latest_version }}
-          files: Artifacts/PluralsightDdd.SharedKernel.${{ needs.ci.outputs.latest_version }}.nupkg
+        shell: pwsh
+        run: |
+          $releaseTag = "v${{ needs.ci.outputs.latest_version }}"
+          $releaseTitle = "PluralsightDdd.SharedKernel v${{ needs.ci.outputs.latest_version }}"
+          $releaseAssets = 'Artifacts/PluralsightDdd.SharedKernel.${{ needs.ci.outputs.latest_version }}.nupkg'
+
+          gh release create $releaseTag --title $releaseTitle $releaseAssets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-cd-sharedkernel.yml
+++ b/.github/workflows/ci-cd-sharedkernel.yml
@@ -1,0 +1,111 @@
+name: SharedKernel CI/CD Pipeline
+
+on:
+  push:
+    paths: [ 'SharedKernel/src/**' ]
+  pull_request:
+    paths: [ 'SharedKernel/src/**' ]
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+    outputs:
+      latest_version: ${{ steps.tag_generator.outputs.new_version }}
+    steps:
+      - name: Data gatherer
+        id: data_gatherer
+        shell: pwsh
+        run: |
+          # Get default branch
+          $repo = "${{ github.repository }}"
+          $defaultBranch = Invoke-RestMethod -Method GET -Uri https://api.github.com/repos/$repo | Select-Object -ExpandProperty default_branch
+          Write-Output "::set-output name=default_branch::$(echo $defaultBranch)"
+
+      - name: Setup .NET Core
+        id: setup_dotnet_core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.102
+
+      - name: Checkout repository
+        id: checkout_repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - if: steps.data_gatherer.outputs.default_branch == 'true'
+        name: Bump GH tag
+        id: tag_generator
+        uses: mathieudutour/github-tag-action@v5.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false
+          release_branches: ${{ steps.data_gatherer.outputs.default_branch }}
+
+      - name: Build solution
+        id: build_solution
+        shell: pwsh
+        run: |
+          dotnet build .\SharedKernel\SharedKernel.sln --configuration Release
+
+      - name: Run unit tests
+        id: run_unit_tests
+        shell: pwsh
+        run: |
+          dotnet test .\SharedKernel\SharedKernel.sln --configuration Release --no-build
+
+      - if: steps.tag_generator.outputs.new_version != ''
+        name: Create NuGet Package
+        id: create_nuget_package
+        shell: pwsh
+        run: |
+          nuget pack .\SharedKernel\src\PluralsightDdd.SharedKernel\PluralsightDdd.SharedKernel.csproj `
+          -OutputDirectory Artifacts `
+          -Properties "Configuration=Release;Version=${{ steps.tag_generator.outputs.new_version }}"
+
+      - if: steps.tag_generator.outputs.new_version != ''
+        name: Upload artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: PluralsightDdd.SharedKernel.${{ steps.tag_generator.outputs.new_version }}
+          path: Artifacts/
+
+  cd:
+    if: needs.ci.outputs.latest_version != ''
+    name: Continuous Deployment
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        id: checkout_repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Download artifacts
+        id: download_artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: PluralsightDdd.SharedKernel.${{ needs.ci.outputs.latest_version }}
+          path: Artifacts/
+
+      - name: Publish to NuGet
+        id: publish_to_nuget
+        shell: pwsh
+        run: |
+          nuget push ./Artifacts/PluralsightDdd.SharedKernel.${{ needs.ci.outputs.latest_version }}.nupkg `
+          -Source https://api.nuget.org/v3/index.json `
+          -ApiKey ${{ secrets.NUGET_API_KEY }}
+
+      - name: Create and publish release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: PluralsightDdd.SharedKernel ${{ needs.ci.outputs.latest_version }}
+          tag_name: v${{ needs.ci.outputs.latest_version }}
+          files: Artifacts/PluralsightDdd.SharedKernel.${{ needs.ci.outputs.latest_version }}.nupkg
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-cd-sharedkernel.yml
+++ b/.github/workflows/ci-cd-sharedkernel.yml
@@ -63,13 +63,13 @@ jobs:
         id: build_solution
         shell: pwsh
         run: |
-          dotnet build .\SharedKernel\SharedKernel.sln --configuration Release
+          dotnet build .\SharedKernel\SharedKernel.sln --configuration Release --output Artifacts
 
       - name: Run unit tests
         id: run_unit_tests
         shell: pwsh
         run: |
-          dotnet test .\SharedKernel\SharedKernel.sln --configuration Release --no-build
+          dotnet test .\SharedKernel\SharedKernel.sln --configuration Release --no-build --output Artifacts
 
       - if: steps.tag_generator.outputs.new_version != ''
         name: Create NuGet Package
@@ -77,16 +77,24 @@ jobs:
         shell: pwsh
         run: |
           nuget pack .\SharedKernel\src\PluralsightDdd.SharedKernel\PluralsightDdd.SharedKernel.csproj `
-          -OutputDirectory Artifacts `
+          -OutputDirectory NuGet `
           -Properties "Configuration=Release;Version=${{ steps.tag_generator.outputs.new_version }}"
 
       - if: steps.tag_generator.outputs.new_version != ''
-        name: Upload artifacts
-        id: upload_artifacts
-        uses: actions/upload-artifact@v1
+        name: Upload build artifacts
+        id: upload_build_artifacts
+        uses: actions/upload-artifact@v2
         with:
-          name: PluralsightDdd.SharedKernel.${{ steps.tag_generator.outputs.new_version }}
+          name: Artifacts
           path: Artifacts/
+
+      - if: steps.tag_generator.outputs.new_version != ''
+        name: Upload NuGet packages
+        id: upload_nuget_packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: NuGet packages
+          path: NuGet/
 
   cd:
     if: needs.ci.outputs.latest_version != ''
@@ -100,18 +108,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download artifacts
+      - name: Download NuGet packages
         id: download_artifacts
         uses: actions/download-artifact@v2
         with:
-          name: PluralsightDdd.SharedKernel.${{ needs.ci.outputs.latest_version }}
-          path: Artifacts/
+          name: NuGet packages
+          path: NuGet/
 
       - name: Publish to NuGet
         id: publish_to_nuget
         shell: pwsh
         run: |
-          nuget push ./Artifacts/PluralsightDdd.SharedKernel.${{ needs.ci.outputs.latest_version }}.nupkg `
+          nuget push NuGet/PluralsightDdd.SharedKernel.${{ needs.ci.outputs.latest_version }}.nupkg `
           -Source https://api.nuget.org/v3/index.json `
           -ApiKey ${{ secrets.NUGET_API_KEY }}
 
@@ -121,7 +129,7 @@ jobs:
         run: |
           $releaseTag = "v${{ needs.ci.outputs.latest_version }}"
           $releaseTitle = "PluralsightDdd.SharedKernel v${{ needs.ci.outputs.latest_version }}"
-          $releaseAssets = 'Artifacts/PluralsightDdd.SharedKernel.${{ needs.ci.outputs.latest_version }}.nupkg'
+          $releaseAssets = 'NuGet/PluralsightDdd.SharedKernel.${{ needs.ci.outputs.latest_version }}.nupkg'
 
           gh release create $releaseTag --title $releaseTitle $releaseAssets
         env:

--- a/.github/workflows/ci-clinicmanagement.yml
+++ b/.github/workflows/ci-clinicmanagement.yml
@@ -28,10 +28,17 @@ jobs:
         id: build_solution
         shell: pwsh
         run: |
-          dotnet build .\ClinicManagement\ClinicManagement.sln --configuration Release
+          dotnet build .\ClinicManagement\ClinicManagement.sln --configuration Release --output Artifacts
 
       - name: Run unit tests
         id: run_unit_tests
         shell: pwsh
         run: |
-          dotnet test .\ClinicManagement\ClinicManagement.sln --configuration Release
+          dotnet test .\ClinicManagement\ClinicManagement.sln --configuration Release --no-build --output Artifacts
+
+      - name: Upload artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Artifacts
+          path: Artifacts/

--- a/.github/workflows/ci-clinicmanagement.yml
+++ b/.github/workflows/ci-clinicmanagement.yml
@@ -1,0 +1,37 @@
+name: ClinicManagement CI Pipeline
+
+on:
+  push:
+    paths: [ 'ClinicManagement/src/**' ]
+  pull_request:
+    paths: [ 'ClinicManagement/src/**' ]
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: windows-latest
+    steps:
+      - name: Setup .NET Core
+        id: setup_dotnet_core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.301
+
+      - name: Checkout repository
+        id: checkout_repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Build solution
+        id: build_solution
+        shell: pwsh
+        run: |
+          dotnet build .\ClinicManagement\ClinicManagement.sln --configuration Release
+
+      - name: Run unit tests
+        id: run_unit_tests
+        shell: pwsh
+        run: |
+          dotnet test .\ClinicManagement\ClinicManagement.sln --configuration Release

--- a/.github/workflows/ci-frontdesk.yml
+++ b/.github/workflows/ci-frontdesk.yml
@@ -1,0 +1,38 @@
+name: FrontDesk CI Pipeline
+
+on:
+  push:
+    paths: [ 'FrontDesk/src/**' ]
+  pull_request:
+    paths: [ 'FrontDesk/src/**' ]
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: windows-latest
+    steps:
+      - name: Setup .NET Core
+        id: setup_dotnet_core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.301
+
+      - name: Checkout repository
+        id: checkout_repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Build solution
+        id: build_solution
+        shell: pwsh
+        run: |
+          dotnet nuget add source ${{ github.workspace }}\FrontDesk\src\FrontDesk.Blazor\deps --name Pluralsight.DDD.Deps
+          dotnet build .\FrontDesk\FrontDesk.sln --configuration Release
+
+      - name: Run unit tests
+        id: run_unit_tests
+        shell: pwsh
+        run: |
+          dotnet test .\FrontDesk\FrontDesk.sln --configuration Release

--- a/.github/workflows/ci-frontdesk.yml
+++ b/.github/workflows/ci-frontdesk.yml
@@ -29,10 +29,17 @@ jobs:
         shell: pwsh
         run: |
           dotnet nuget add source ${{ github.workspace }}\FrontDesk\src\FrontDesk.Blazor\deps --name Pluralsight.DDD.Deps
-          dotnet build .\FrontDesk\FrontDesk.sln --configuration Release
+          dotnet build .\FrontDesk\FrontDesk.sln --configuration Release --output Artifacts
 
       - name: Run unit tests
         id: run_unit_tests
         shell: pwsh
         run: |
-          dotnet test .\FrontDesk\FrontDesk.sln --configuration Release
+          dotnet test .\FrontDesk\FrontDesk.sln --configuration Release --no-build --output Artifacts
+
+      - name: Upload artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Artifacts
+          path: Artifacts/

--- a/.github/workflows/ci-vetclinicpublic.yml
+++ b/.github/workflows/ci-vetclinicpublic.yml
@@ -1,0 +1,37 @@
+name: VetClinicPublic CI Pipeline
+
+on:
+  push:
+    paths: [ 'VetClinicPublic/src/**' ]
+  pull_request:
+    paths: [ 'VetClinicPublic/src/**' ]
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: windows-latest
+    steps:
+      - name: Setup .NET Core
+        id: setup_dotnet_core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.301
+
+      - name: Checkout repository
+        id: checkout_repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Build solution
+        id: build_solution
+        shell: pwsh
+        run: |
+          dotnet build .\VetClinicPublic\VetClinicPublic.sln --configuration Release
+
+      - name: Run unit tests
+        id: run_unit_tests
+        shell: pwsh
+        run: |
+          dotnet test .\VetClinicPublic\VetClinicPublic.sln --configuration Release

--- a/.github/workflows/ci-vetclinicpublic.yml
+++ b/.github/workflows/ci-vetclinicpublic.yml
@@ -28,10 +28,17 @@ jobs:
         id: build_solution
         shell: pwsh
         run: |
-          dotnet build .\VetClinicPublic\VetClinicPublic.sln --configuration Release
+          dotnet build .\VetClinicPublic\VetClinicPublic.sln --configuration Release --output Artifacts
 
       - name: Run unit tests
         id: run_unit_tests
         shell: pwsh
         run: |
-          dotnet test .\VetClinicPublic\VetClinicPublic.sln --configuration Release
+          dotnet test .\VetClinicPublic\VetClinicPublic.sln --configuration Release --no-build --output Artifacts
+
+      - name: Upload artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Artifacts
+          path: Artifacts/


### PR DESCRIPTION
The ci-cd-sharedkernel pipeline runs:

1. CI

- automated Semantic Versioning
- projects build
- unit tests
- publishing pipeline artifacts
- create NuGet package

2. CD

- publishing to NuGet
- automated GitHub Release publish

We also created CI pipelines for the other 3 projects in the repo (ClinicManagement, FrontDesk and VetClinicPublic ).
 
With:
- project build
- unit tests
- publish pipeline artifacts

With this contribution, we consolidate the current pipelines into a single pipeline and CI pipelines for the other projects in the repository. Also we added some additional features like "Automated GitHub Release", "Publishing Pipeline Artifacts" and "Automated Semantic Versioning" to the ci-cdsharedkernel pipeline, so please let us know if anything could be done better and/or if any other automation is required by the project! We would be happy to improve it to satisfactory completion 🙂

Resolves #30 