### PR TITLE
fix link to ardalis/Specification repository

### DIFF
--- a/FrontDesk/src/FrontDesk.Infrastructure/Data/EfRepository.cs
+++ b/FrontDesk/src/FrontDesk.Infrastructure/Data/EfRepository.cs
@@ -4,7 +4,7 @@ using PluralsightDdd.SharedKernel.Interfaces;
 namespace FrontDesk.Infrastructure.Data
 {
   // We are using the EfRepository from Ardalis.Specification
-  // https://github.com/ardalis/Specification/blob/v5/ArdalisSpecificationEF/src/Ardalis.Specification.EF/RepositoryBaseOfT.cs
+  // https://github.com/ardalis/Specification/blob/v5.1.0/ArdalisSpecificationEF/src/Ardalis.Specification.EF/RepositoryBaseOfT.cs
   public class EfRepository<T> : RepositoryBase<T>, IRepository<T> where T : class, IAggregateRoot
   {
     public EfRepository(AppDbContext dbContext) : base(dbContext)


### PR DESCRIPTION
Hello! I find a typo in the file EfRepository.cs, in which there was a link pointing to a non-existing file in the repository ardalis/Specification. I fixed it by replacing 'v5' with 'v5.1.0'.