### PR TITLE
Refactor Schedule.AddNewAppointment to abide by the CQS principle

### DIFF
--- a/FrontDesk/src/FrontDesk.Core/ScheduleAggregate/Schedule.cs
+++ b/FrontDesk/src/FrontDesk.Core/ScheduleAggregate/Schedule.cs
@@ -31,7 +31,7 @@ namespace FrontDesk.Core.ScheduleAggregate
 
     public DateTimeOffsetRange DateRange { get; private set; }
 
-    public Appointment AddNewAppointment(Appointment appointment)
+    public void AddNewAppointment(Appointment appointment)
     {
       Guard.Against.Null(appointment, nameof(appointment));
       Guard.Against.Default(appointment.Id, nameof(appointment.Id));
@@ -43,8 +43,6 @@ namespace FrontDesk.Core.ScheduleAggregate
 
       var appointmentScheduledEvent = new AppointmentScheduledEvent(appointment);
       Events.Add(appointmentScheduledEvent);
-
-      return appointment;
     }
 
     public void DeleteAppointment(Appointment appointment)


### PR DESCRIPTION
In practice `AddNewAppointment` is a command method, it has side effects and mutates the object. As such the CQS principle would want the method to not return anything. There isn't a single place in the app where we actually do anything with the returned `Appointment`. I figure we might as well mark the return as `void`.

I guess this change also follows the principle of least astonishment. I was 'surprised' to see this method return a value and a bit confused as to why, seeing as we didn't use that value anywhere. 🙂