### PR TITLE
Fix issue with parsing date with hardcoded format

### DIFF
--- a/FrontDesk/src/FrontDesk.Blazor/Services/ConfigurationService.cs
+++ b/FrontDesk/src/FrontDesk.Blazor/Services/ConfigurationService.cs
@@ -21,7 +21,7 @@ namespace FrontDesk.Blazor.Services
       _logger.LogInformation("Read today date/time from configuration.");
 
       var stringDateTimeOffset = await _httpService.HttpGetAsync($"api/configurations");
-      var dateTimeWithOffset = DateTimeOffset.ParseExact(stringDateTimeOffset, "MM/dd/yyyy HH:mm:ss zzz", CultureInfo.InvariantCulture);
+      var dateTimeWithOffset = DateTimeOffset.Parse(stringDateTimeOffset, CultureInfo.InvariantCulture);
 
       return dateTimeWithOffset.UtcDateTime;
     }


### PR DESCRIPTION
We are creating a DateTimeOffset on the server and sending it in string format to the client. There, using ParseExact and a hardcoded US date format, we are converting it back to a DateTimeOffset.

The problem is that when the date is created on a server that is in a non-US locale, the client throws and error and the app crashes.