### PR TITLE
Fix launchSettings.json parsing error

### DIFF
--- a/ClinicManagement/src/ClinicManagement.Blazor/Properties/launchSettings.json
+++ b/ClinicManagement/src/ClinicManagement.Blazor/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "iisSettings": {
     "windowsAuthentication": false,
-    "anonymousAuthentication": true,
+    "anonymousAuthentication": true
   },
   "profiles": {
     "ClinicManagement.Blazor": {

--- a/FrontDesk/src/FrontDesk.Api/Properties/launchSettings.json
+++ b/FrontDesk/src/FrontDesk.Api/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "iisSettings": {
     "windowsAuthentication": false,
-    "anonymousAuthentication": true,
+    "anonymousAuthentication": true
   },
   "profiles": {
     "FrontDesk.Api": {

--- a/FrontDesk/src/FrontDesk.Blazor/Properties/launchSettings.json
+++ b/FrontDesk/src/FrontDesk.Blazor/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "iisSettings": {
     "windowsAuthentication": false,
-    "anonymousAuthentication": true,
+    "anonymousAuthentication": true
   },
   "profiles": {
     "FrontDesk.Blazor": {


### PR DESCRIPTION
While this is ignored by Visual Studio, JetBrains Ryder is less forgiving and fails to detect the Kestrel configuration in the affected projects. This results in a silent fallback to a default profile that uses 5000-5001 port numbers.